### PR TITLE
Improves the LuaJIT performance by using luaL_openlibs to initialize the VM

### DIFF
--- a/src/LuaJITEngine.cpp
+++ b/src/LuaJITEngine.cpp
@@ -28,16 +28,12 @@ struct LuaJITEngine : ScriptEngine {
 			return -1;
 		}
 
-		// Import the common Lua libraries
-		luaL_openlibs(L);
-		// Unloads the unsafe libraries
-		lua_pushinteger(L, 0);
-		lua_setglobal(L, "os");
-		lua_pushinteger(L, 0);
-		lua_setglobal(L, "io");
-		// Unloads 'require' so 'io' and 'os' cannot be reloaded
-		lua_pushinteger(L, 0);
-		lua_setglobal(L, "require");
+		// Import a subset of the standard library
+		luaopen_base(L);
+		luaopen_string(L);
+		luaopen_table(L);
+		luaopen_math(L);
+		luaopen_bit(L);
 
 		// Set user pointer
 		lua_pushlightuserdata(L, this);

--- a/src/LuaJITEngine.cpp
+++ b/src/LuaJITEngine.cpp
@@ -28,12 +28,16 @@ struct LuaJITEngine : ScriptEngine {
 			return -1;
 		}
 
-		// Import a subset of the standard library
-		luaopen_base(L);
-		luaopen_string(L);
-		luaopen_table(L);
-		luaopen_math(L);
-		luaopen_bit(L);
+		// Import the common Lua libraries
+		luaL_openlibs(L);
+		// Unloads the unsafe libraries
+		lua_pushinteger(L, 0);
+		lua_setglobal(L, "os");
+		lua_pushinteger(L, 0);
+		lua_setglobal(L, "io");
+		// Unloads 'require' so 'io' and 'os' cannot be reloaded
+		lua_pushinteger(L, 0);
+		lua_setglobal(L, "require");
 
 		// Set user pointer
 		lua_pushlightuserdata(L, this);

--- a/src/LuaJITEngine.cpp
+++ b/src/LuaJITEngine.cpp
@@ -34,6 +34,11 @@ struct LuaJITEngine : ScriptEngine {
 		luaopen_table(L);
 		luaopen_math(L);
 		luaopen_bit(L);
+		// Loads the JIT package otherwise it will be off
+		luaopen_jit(L);
+		// Diables access to the JIT package
+		lua_pushnil(L);
+		lua_setglobal(L,"jit");
 
 		// Set user pointer
 		lua_pushlightuserdata(L, this);

--- a/src/LuaJITEngine.cpp
+++ b/src/LuaJITEngine.cpp
@@ -36,7 +36,7 @@ struct LuaJITEngine : ScriptEngine {
 		luaopen_bit(L);
 		// Loads the JIT package otherwise it will be off
 		luaopen_jit(L);
-		// Diables access to the JIT package
+		// Disables access to the JIT package
 		lua_pushnil(L);
 		lua_setglobal(L,"jit");
 


### PR DESCRIPTION
As I mentioned in my other pull request. This change doubles the performance of my complex Lua code. In order to forbid the unsafe libraries, like `io` and `os`, they are set to nil just after initializing the VM.

I also set to `nil` the function `require` that way no other libraries can be loaded.