### PR TITLE
Fix extension handling to work with the V2 SDK.

### DIFF
--- a/src/DuktapeEngine.cpp
+++ b/src/DuktapeEngine.cpp
@@ -219,5 +219,5 @@ struct DuktapeEngine : ScriptEngine {
 
 __attribute__((constructor(1000)))
 static void constructor() {
-	addScriptEngine<DuktapeEngine>("js");
+	addScriptEngine<DuktapeEngine>(".js");
 }

--- a/src/FaustEngine.cpp
+++ b/src/FaustEngine.cpp
@@ -369,5 +369,5 @@ private:
 
 __attribute__((constructor(1000)))
 static void constructor() {
-	addScriptEngine<FaustEngine>("dsp");
+	addScriptEngine<FaustEngine>(".dsp");
 }

--- a/src/LibPDEngine.cpp
+++ b/src/LibPDEngine.cpp
@@ -331,5 +331,5 @@ void LibPDEngine::sendInitialStates(const ProcessBlock* block) {
 
 __attribute__((constructor(1000)))
 static void constructor() {
-	addScriptEngine<LibPDEngine>("pd");
+	addScriptEngine<LibPDEngine>(".pd");
 }

--- a/src/LuaJITEngine.cpp
+++ b/src/LuaJITEngine.cpp
@@ -246,5 +246,5 @@ struct LuaJITEngine : ScriptEngine {
 
 __attribute__((constructor(1000)))
 static void constructor() {
-	addScriptEngine<LuaJITEngine>("lua");
+	addScriptEngine<LuaJITEngine>(".lua");
 }

--- a/src/Prototype.cpp
+++ b/src/Prototype.cpp
@@ -334,7 +334,7 @@ struct Prototype : Module {
 		std::string extension = system::getExtension(path);
 		scriptEngine = createScriptEngine(extension);
 		if (!scriptEngine) {
-			message = string::f("No engine for .%s extension", extension.c_str());
+			message = string::f("No engine for %s extension", extension.c_str());
 			return;
 		}
 		scriptEngine->module = this;
@@ -406,13 +406,13 @@ struct Prototype : Module {
 	}
 
 	void newScriptDialog() {
-		std::string ext = "js";
+		std::string ext = ".js";
 		// Get current extension if a script is currently loaded
 		if (!path.empty()) {
 			ext = system::getExtension(path);
 		}
 		std::string dir = asset::plugin(pluginInstance, "examples");
-		std::string filename = "Untitled." + ext;
+		std::string filename = "Untitled" + ext;
 		char* newPathC = osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), NULL);
 		if (!newPathC) {
 			return;
@@ -436,7 +436,7 @@ struct Prototype : Module {
 		}
 
 		// Copy template to new script
-		std::string templatePath = asset::plugin(pluginInstance, "examples/template." + ext);
+		std::string templatePath = asset::plugin(pluginInstance, "examples/template" + ext);
 		{
 			std::ifstream templateFile(templatePath, std::ios::binary);
 			std::ofstream newFile(newPath, std::ios::binary);
@@ -468,7 +468,7 @@ struct Prototype : Module {
 
 		std::string ext = system::getExtension(path);
 		std::string dir = asset::plugin(pluginInstance, "examples");
-		std::string filename = "Untitled." + ext;
+		std::string filename = "Untitled" + ext;
 		char* newPathC = osdialog_file(OSDIALOG_SAVE, dir.c_str(), filename.c_str(), NULL);
 		if (!newPathC) {
 			return;
@@ -478,7 +478,7 @@ struct Prototype : Module {
 		// Add extension if user didn't specify one
 		std::string newExt = system::getExtension(newPath);
 		if (newExt == "")
-			newPath += "." + ext;
+			newPath += ext;
 
 		// Write and close file
 		{
@@ -594,7 +594,7 @@ struct Prototype : Module {
 		if (path == "")
 			return "";
 		// HACK check if extension is .pd
-		if (system::getExtension(path) == "pd")
+		if (system::getExtension(path) == ".pd")
 			return settingsPdEditorPath;
 		return settingsEditorPath;
 	}

--- a/src/PythonEngine.cpp
+++ b/src/PythonEngine.cpp
@@ -252,5 +252,5 @@ struct PythonEngine : ScriptEngine {
 
 __attribute__((constructor(1000)))
 static void constructor() {
-	addScriptEngine<PythonEngine>("py");
+	addScriptEngine<PythonEngine>(".py");
 }

--- a/src/QuickJSEngine.cpp
+++ b/src/QuickJSEngine.cpp
@@ -329,5 +329,5 @@ struct QuickJSEngine : ScriptEngine {
 
 __attribute__((constructor(1000)))
 static void constructor() {
-  addScriptEngine<QuickJSEngine>("js");
+  addScriptEngine<QuickJSEngine>(".js");
 }

--- a/src/SuperColliderEngine.cpp
+++ b/src/SuperColliderEngine.cpp
@@ -405,6 +405,6 @@ bool SC_VcvPrototypeClient::copyArrayOfFloatArrays(const PyrSlot& inSlot, const 
 
 __attribute__((constructor(1000)))
 static void constructor() {
-	addScriptEngine<SuperColliderEngine>("sc");
-	addScriptEngine<SuperColliderEngine>("scd");
+	addScriptEngine<SuperColliderEngine>(".sc");
+	addScriptEngine<SuperColliderEngine>(".scd");
 }

--- a/src/VultEngine.cpp
+++ b/src/VultEngine.cpp
@@ -150,5 +150,5 @@ struct VultEngine : ScriptEngine {
 
 __attribute__((constructor(1000)))
 static void constructor() {
-	addScriptEngine<VultEngine>("vult");
+	addScriptEngine<VultEngine>(".vult");
 }


### PR DESCRIPTION
This fixes extension handling and registration to work with V2 by using strings that include the leading `.`.

The V2 SDK's `system::getExtension` returns strings with a leading `.` (as it uses [std::filesystem::path::extension](https://en.cppreference.com/w/cpp/filesystem/path/extension) under the hood) whereas V1's `string::filenameExtension` doesn't. 

#61 