### PR TITLE
remove superfluous build flags for libpd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ libpd := dep/lib/libpd.a
 SOURCES += src/LibPDEngine.cpp
 OBJECTS += $(libpd)
 DEPS += $(libpd)
-FLAGS += -Idep/include/libpd -DHAVE_LIBDL -DPDINSTANCE -DPDTHREADS
+FLAGS += -Idep/include/libpd -DHAVE_LIBDL
 
 ifdef ARCH_WIN
 	# PD_INTERNAL leaves the function declarations for libpd unchanged


### PR DESCRIPTION
these flags are set in the libpd makefile internally when building the multi instance target as we do with the `MULTI=true` build parameter